### PR TITLE
Configure Remote State Backend for Terraform

### DIFF
--- a/01_api_demo/simple_api/infra/backend.tf
+++ b/01_api_demo/simple_api/infra/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "simple-api-state-be"
+    key            = "simple_api/terraform.tfstate"
+    region         = "us-east-1"         
+    encrypt        = true
+    dynamodb_table = "terraform-locks"
+    # profile      = "your-aws-cli-profile" # optional
+  }
+}


### PR DESCRIPTION

Added backend.tf to swap out local state for an S3-backed remote state with DynamoDB locking.

Reliability: Prevents state file drift and concurrent writes.

Security: Server-side encryption and versioning on the S3 bucket.